### PR TITLE
Replaced the use of deprecated preg_replace with /e modifier with preg_replace_callback in ContextualValidator::bindReplacements.

### DIFF
--- a/src/Crhayes/Validation/ContextualValidator.php
+++ b/src/Crhayes/Validation/ContextualValidator.php
@@ -214,7 +214,10 @@ abstract class ContextualValidator implements MessageProviderInterface
 
 			try
 			{
-				$rule = preg_replace('/@(\w+)/e', '$replacements["$1"]', $rule);
+				$rule = preg_replace_callback('/@(\w+)/', function($matches) use($replacements)
+				{
+					return $replacements[$matches[1]];
+				}, $rule);
 			}
 			catch (\ErrorException $e)
 			{


### PR DESCRIPTION
Using preg_replace with /e modifier is deprecated in PHP 5.5, resulting in error exception being always thrown on the method call. Fixed by replacing the function call with preg_replace_callback.
