### PR TITLE
Favour protected over private

### DIFF
--- a/src/Crhayes/Validation/ContextualValidator.php
+++ b/src/Crhayes/Validation/ContextualValidator.php
@@ -230,7 +230,7 @@ abstract class ContextualValidator implements MessageProviderInterface
 	 * 
 	 * @return array
 	 */
-	private function getRulesInContext()
+	protected function getRulesInContext()
 	{
 		if ( ! $this->hasContext())	return $this->rules;
 
@@ -262,7 +262,7 @@ abstract class ContextualValidator implements MessageProviderInterface
 	 * @param  array 	$rules
 	 * @return array
 	 */
-	private function bindReplacements($rules)
+	protected function bindReplacements($rules)
 	{
 		foreach ($rules as $field => &$rule)
 		{
@@ -299,7 +299,7 @@ abstract class ContextualValidator implements MessageProviderInterface
 	 * 
 	 * @return boolean
 	 */
-	private function hasContext()
+	protected function hasContext()
 	{
 		return (count($this->contexts) OR array_get($this->rules, self::DEFAULT_KEY));
 	}

--- a/src/Crhayes/Validation/GroupedValidator.php
+++ b/src/Crhayes/Validation/GroupedValidator.php
@@ -13,14 +13,14 @@ class GroupedValidator
 	 * 
 	 * @var array
 	 */
-	private $validators = array();
+	protected $validators = array();
 
 	/**
 	 * An array of errors returned from all of the validators.
 	 * 
 	 * @var array
 	 */
-	private $errors = array();
+	protected $errors = array();
 
 	/**
 	 * Create a new GroupedValidator, with the option of specifying


### PR DESCRIPTION
Trying to make a contextual model validation plugin for Laravel but can not depend upon this library as I wish to override the getRulesInContext method to use array_merge_recursive, this was general rules for save can be defined in default, then specific rules can be defined in create/update and merged in.

Also, I find it to generally be a good idea to favour protected when I am unsure as to whether the method will need to be overridden.
