### PR TITLE
Remove deprecated service provider package naming

### DIFF
--- a/src/Crhayes/Validation/ValidationServiceProvider.php
+++ b/src/Crhayes/Validation/ValidationServiceProvider.php
@@ -18,7 +18,7 @@ class ValidationServiceProvider extends ServiceProvider {
 	 */
 	public function boot()
 	{
-		$this->package('crhayes/validation');
+		//
 	}
 
 	/**


### PR DESCRIPTION
Quick fix for https://github.com/crhayes/laravel-extended-validator/issues/16
