### PR TITLE
Add posibility to specify custom attributes names

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ class UserValidator extends ContextualValidator
     protected $messages = [
         'first_name.required' => 'First name is required!'
     ];
+
+    protected $attributeNames = [
+        'last_name' => 'Last Name'
+    ];
 }
 ```
 This service is then instantiated and the validation works much the same as Laravel's built-in validation.

--- a/src/Crhayes/Validation/ContextualValidator.php
+++ b/src/Crhayes/Validation/ContextualValidator.php
@@ -34,6 +34,13 @@ abstract class ContextualValidator implements MessageProvider
 	protected $messages = array();
 
 	/**
+	 * Store any custom names of attributes.
+	 *
+	 * @var array
+	 */
+	protected $attributeNames = array();
+
+	/**
 	 * Store any contexts we are validating within.
 	 *
 	 * @var array
@@ -182,7 +189,12 @@ abstract class ContextualValidator implements MessageProvider
 	{
 		$rules = $this->bindReplacements($this->getRulesInContext());
 
-		$validator = Validator::make($this->attributes, $rules, $this->messages);
+		$validator = Validator::make(
+			$this->attributes,
+			$rules,
+			$this->messages,
+			$this->attributeNames
+		);
 
 		$this->addConditionalRules($validator);
 


### PR DESCRIPTION
Resolves #11

For example,

``` php
class UserValidator extends ContextualValidator
{
    protected $rules = [
        'first_name' => 'required'
    ];

    protected $attributeNames= [
        'first_name' => 'First name'
    ];
}

$userValidator = UserValidator::make([]]);
$errors = $userValidator->errors();
```

Outputs `The First name field is required.`.
